### PR TITLE
fixed reading workspace images

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ This field will show an error if data cannot be parsed
 
 ### Textures
 
-| Name            | Description                           |
-| --------------- | ------------------------------------- |
-| Url             | Custom texture url                    |
-| Workspace       | Allows setting texture from workspace |
-| Binding - Grass | Extension texture                     |
-| Binding - Sky   | Extension texture                     |
-| Binding - Egypt | Extension texture                     |
+| Name            | Description                                      |
+| --------------- | ------------------------------------------------ |
+| Url             | Custom texture url                               |
+| Workspace       | Allows setting texture from workspace (jpg, png) |
+| Binding - Grass | Extension texture                                |
+| Binding - Sky   | Extension texture                                |
+| Binding - Egypt | Extension texture                                |
 
 Url will show an error if the extension cannot fetch the image due to security reasons.
 Workspace images are not always working and might be blocked, depends on the image.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "WebGL Shader Viewer",
   "description": "WebGL Shader Viewer",
   "publisher": "mateuszmigas",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/mateuszmigas/webgl-shader-viewer.git"

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,6 +1,6 @@
 import { translations } from "./translations";
 export const shaderExtensions = ["glsl"];
-export const imagesExtensions = ["jpg"];
+export const imagesExtensions = ["jpg", "png"];
 export const customOption = { id: "custom", display: translations.custom } as const;
 export const customImageUrl = { id: "url", display: "Url" } as const;
 export const workspaceImageUrl = { id: "workspace", display: "Workspace" } as const;

--- a/src/common/translations.ts
+++ b/src/common/translations.ts
@@ -19,7 +19,7 @@ export const translations = {
   },
   errors: {
     fetchingImage: "Unable to fetch image",
-    emptyUrl: "URL cannot be empty",
+    emptyField: "Field cannot be empty",
     program: "PROGRAM:",
     vertexShader: "VERTEX SHADER:",
     fragmentShader: "FRAGMENT SHADER:",

--- a/src/communication/messages.ts
+++ b/src/communication/messages.ts
@@ -6,6 +6,7 @@ export type MessageRequest =
       payload: { extensions: string[] };
     }
   | { type: "getDocumentText"; id: string; payload: { fileName: string } }
+  | { type: "getImageBase64Data"; id: string; payload: { filePath: string } }
   | { type: "getExtensionFileUri"; id: string; payload: { fileName: string } }
   | { type: "subscribeToDocumentTextChange"; payload: { fileName: string } }
   | { type: "unsubscribeToDocumentTextChange"; payload: { fileName: string } }
@@ -22,6 +23,11 @@ export type MessageResponse =
       type: "getDocumentText";
       id: string;
       payload: { fileName: string; text: string };
+    }
+  | {
+      type: "getImageBase64Data";
+      id: string;
+      payload: { base64Data: string };
     }
   | {
       type: "getExtensionFileUri";

--- a/src/communication/panelEndpoint.ts
+++ b/src/communication/panelEndpoint.ts
@@ -59,6 +59,18 @@ export const panelEndpoint = (
         });
         break;
       }
+      case "getImageBase64Data": {
+        const type = path.extname(message.payload.filePath).replace(".", "").toLowerCase();
+        vscode.workspace.fs.readFile(vscode.Uri.file(message.payload.filePath)).then(data => {
+          postMessage({
+            ...message,
+            payload: {
+              base64Data: `data:image/${type};base64, ${Buffer.from(data).toString("base64")}`,
+            },
+          });
+        });
+        break;
+      }
       case "getExtensionFileUri": {
         const uri = getMediaUri(message.payload.fileName);
         postMessage({

--- a/src/communication/viewerEndpoint.ts
+++ b/src/communication/viewerEndpoint.ts
@@ -57,6 +57,27 @@ class ViewerEndpoint {
     });
   }
 
+  getImageBase64Data(filePath: string) {
+    const messageId = uuidv4();
+
+    vscodeApi.postMessage({
+      type: "getImageBase64Data",
+      id: messageId,
+      payload: { filePath },
+    });
+
+    return new Promise<string>(resolve => {
+      const listener = (message: MessageResponse) => {
+        if (message.type === "getImageBase64Data" && message.id === messageId) {
+          resolve(message.payload.base64Data);
+          this.removeListener(listener);
+        }
+      };
+
+      this.eventListeners.push(listener);
+    });
+  }
+
   getExtensionFileUri(fileName: string) {
     const messageId = uuidv4();
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -78,7 +78,7 @@ export class Panel {
                   Use a content security policy to only allow loading images from https or from our extension directory,
                   and only allow scripts that have a specific nonce.
               -->
-              <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${codiconsFontUri}; style-src ${webview.cspSource} ${codiconsUri}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
+              <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${codiconsFontUri}; style-src ${webview.cspSource} ${codiconsUri}; img-src ${webview.cspSource} data: https:; script-src 'nonce-${nonce}';">
               <meta name="viewport" content="width=device-width, initial-scale=1.0">
               <link href="${stylesUri}" rel="stylesheet">
               <link href="${codiconsUri}" rel="stylesheet" />

--- a/src/utils/webgl/stateSynchronizer.ts
+++ b/src/utils/webgl/stateSynchronizer.ts
@@ -52,11 +52,12 @@ const setTexture = async (
   }
 
   const binding = getTextureBinding(optionId);
-  const uri = binding
+  const src = binding
     ? await viewerEndpoint.getExtensionFileUri(binding.fileName)
     : optionId === customImageUrl.id
     ? customUrl
-    : workspaceUrl;
+    : await viewerEndpoint.getImageBase64Data(workspaceUrl);
+
   const setError = (error: string) => {
     store.dispatch({
       type: "SET_TEXTURE_LOADING_ERROR",
@@ -65,11 +66,11 @@ const setTexture = async (
     error && textureInfo.setPlaceholderTexture();
   };
 
-  if (!uri) {
-    setError(translations.errors.emptyUrl);
+  if (!src) {
+    setError(translations.errors.emptyField);
   } else {
     try {
-      const img = await loadImage(uri);
+      const img = await loadImage(src);
       textureInfo.setSource(img);
       setError("");
     } catch {

--- a/src/viewer/components/Viewer.tsx
+++ b/src/viewer/components/Viewer.tsx
@@ -87,7 +87,9 @@ export const Viewer = React.memo(() => {
       }))
     );
 
-    setWorkspaceImageOptions(imageFiles.map(file => ({ id: file.uri, display: file.fileName })));
+    setWorkspaceImageOptions(
+      imageFiles.map(file => ({ id: file.filePath, display: file.fileName }))
+    );
   }, [setWorkspaceShaderOptions, setWorkspaceImageOptions]);
 
   //startup


### PR DESCRIPTION
vscode webview doesn't like loading workspace images. After so many tries finally decided to pass this as base64 encoded data from extension to webview.

fixes #6